### PR TITLE
Remove key warning

### DIFF
--- a/src/components/AvatarBackground.vue
+++ b/src/components/AvatarBackground.vue
@@ -3,15 +3,16 @@
     <div
       v-if="showExclusionZone"
       class="absolute ba b--red b--dashed o-50"
-      :style="{ 
+      :style="{
         left: `${excludeZone.minX}px`,
         right: `${clientWidth - excludeZone.maxX}px`,
         top: `${excludeZone.minY}px`,
-        bottom: `${clientHeight - excludeZone.maxY}px`,
+        bottom: `${clientHeight - excludeZone.maxY}px`
       }"
     ></div>
     <AvatarItem
-      v-for="avatar in avatarsHydrated"
+      v-for="(avatar, index) in avatarsHydrated"
+      :key="index"
       :type="avatar.type"
       :bgImageSrc="avatar.bgImageSrc"
       :style="avatar.style"
@@ -25,7 +26,7 @@ import AvatarItem from "./AvatarItem";
 export default {
   name: "AvatarBackground",
   components: {
-    AvatarItem,
+    AvatarItem
   },
   data: function() {
     return {
@@ -35,91 +36,98 @@ export default {
       // 0.5 = allow upto half of avatar size to overlap
       // 1   = allow upto 'border to border' fit
       // 1.5 = require at least half of avatar size in between
-      separationFactor: 1.1,
-    }
+      separationFactor: 1.1
+    };
   },
   props: {
     avatars: { type: Array, default: () => [] },
     excludeZoneRatios: { type: Object },
-    showExclusionZone: { type: Boolean, default: false },
+    showExclusionZone: { type: Boolean, default: false }
   },
   computed: {
-    clientWidth () {
-      return document.body.clientWidth || document.documentElement.clientWidth
+    clientWidth() {
+      return document.body.clientWidth || document.documentElement.clientWidth;
     },
-    clientHeight () {
-      return document.body.clientHeight || document.documentElement.clientHeight
+    clientHeight() {
+      return (
+        document.body.clientHeight || document.documentElement.clientHeight
+      );
     },
-    excludeZone () {
+    excludeZone() {
       return {
         minX: this.excludeZoneRatios.minX * this.clientWidth,
         maxX: this.excludeZoneRatios.maxX * this.clientWidth,
         minY: this.excludeZoneRatios.minY * this.clientHeight,
-        maxY: this.excludeZoneRatios.maxY * this.clientHeight,
-      }
-    },
+        maxY: this.excludeZoneRatios.maxY * this.clientHeight
+      };
+    }
   },
   methods: {
-    randomPos () {
+    randomPos() {
       return {
         x: Math.random() * this.clientWidth,
-        y: Math.random() * this.clientHeight,
-      }
+        y: Math.random() * this.clientHeight
+      };
     },
-    randomPosExclusive () {
-      let randomPos = this.randomPos()
+    randomPosExclusive() {
+      let randomPos = this.randomPos();
       return this.overlaps(randomPos, this.excludeZone)
         ? this.randomPosExclusive()
-        : randomPos
+        : randomPos;
     },
-    getStyleForPos (pos) {
-      return { 
-        left: pos.x - (0.5 * this.avatarSize) + 'px',
-        top: pos.y - (0.5 * this.avatarSize) + 'px',
-      }
+    getStyleForPos(pos) {
+      return {
+        left: pos.x - 0.5 * this.avatarSize + "px",
+        top: pos.y - 0.5 * this.avatarSize + "px"
+      };
     },
-    overlaps (pos, excludeArea) {
-      return pos.x > excludeArea.minX &&
-             pos.x < excludeArea.maxX &&
-             pos.y > excludeArea.minY &&
-             pos.y < excludeArea.maxY
+    overlaps(pos, excludeArea) {
+      return (
+        pos.x > excludeArea.minX &&
+        pos.x < excludeArea.maxX &&
+        pos.y > excludeArea.minY &&
+        pos.y < excludeArea.maxY
+      );
     },
-    overlapsPositions (candidatePos, existingPositions) {
+    overlapsPositions(candidatePos, existingPositions) {
       return existingPositions.some(pos => {
-        return this.overlaps(candidatePos, this.getAreaForPos(pos, this.avatarSize))
-      })
+        return this.overlaps(
+          candidatePos,
+          this.getAreaForPos(pos, this.avatarSize)
+        );
+      });
     },
-    getAreaForPos (pos, size) {
+    getAreaForPos(pos, size) {
       return {
         minX: pos.x - this.separationFactor * size,
         maxX: pos.x + this.separationFactor * size,
         minY: pos.y - this.separationFactor * size,
         maxY: pos.y + this.separationFactor * size
-      }
+      };
     },
-    hydrateOneAvatar (avatar) {
-      let candidatePos = this.randomPosExclusive()
-      let existingPositions = this.avatarsHydrated.map(a => a.pos)
+    hydrateOneAvatar(avatar) {
+      let candidatePos = this.randomPosExclusive();
+      let existingPositions = this.avatarsHydrated.map(a => a.pos);
       if (!this.overlapsPositions(candidatePos, existingPositions)) {
         this.avatarsHydrated.push({
           type: avatar.type,
           bgImageSrc: avatar.bgImageSrc,
           style: this.getStyleForPos(candidatePos),
           pos: candidatePos
-        })
+        });
       } else {
-        this.hydrateOneAvatar(avatar)
+        this.hydrateOneAvatar(avatar);
       }
     },
-    hydrateAvatars () {
+    hydrateAvatars() {
       this.avatars.forEach(avatar => {
-        this.hydrateOneAvatar(avatar)
-      })
-    },
+        this.hydrateOneAvatar(avatar);
+      });
+    }
   },
-  created () {
-    this.hydrateAvatars()
-  },
+  created() {
+    this.hydrateAvatars();
+  }
 };
 </script>
 

--- a/src/components/CorrespondenceList.vue
+++ b/src/components/CorrespondenceList.vue
@@ -1,11 +1,12 @@
 <template>
   <section>
-    <CorrespondenceCard 
+    <CorrespondenceCard
       v-for="correspondence in correspondences"
-      :names='correspondence.names' 
-      :backgroundIds='correspondence.backgroundIds' 
-      :numberLetters='correspondence.numberLetters' 
-      :curatorialStatement='correspondence.curatorialStatement'
+      :key="correspondence.names.join()"
+      :names="correspondence.names"
+      :backgroundIds="correspondence.backgroundIds"
+      :numberLetters="correspondence.numberLetters"
+      :curatorialStatement="correspondence.curatorialStatement"
       class="ma3 dib v-top"
     />
   </section>
@@ -16,10 +17,10 @@ import CorrespondenceCard from "./CorrespondenceCard";
 export default {
   name: "CorrespondenceList",
   components: {
-    CorrespondenceCard,
+    CorrespondenceCard
   },
   props: {
-    correspondences: { type: Array, default: () => [] },
-  },
+    correspondences: { type: Array, default: () => [] }
+  }
 };
 </script>

--- a/src/components/EntityList.vue
+++ b/src/components/EntityList.vue
@@ -2,6 +2,7 @@
   <senction class="entity-list">
     <EntityCard
       v-for="entity in entitiesFiltered"
+      :key="entity.title"
       :type="entity.type"
       :title="entity.title"
       :bgImageSrc="entity.bgImageSrc"
@@ -15,18 +16,18 @@ import EntityCard from "./EntityCard";
 export default {
   name: "EntityList",
   components: {
-    EntityCard,
+    EntityCard
   },
   props: {
     entities: { type: Array, default: () => [] },
-    typeFilter: { type: String },
+    typeFilter: { type: String }
   },
   computed: {
-    entitiesFiltered () {
-      return this.typeFilter 
+    entitiesFiltered() {
+      return this.typeFilter
         ? this.entities.filter(entity => entity.type === this.typeFilter)
-        : this.entities
-    },
+        : this.entities;
+    }
   }
 };
 </script>


### PR DESCRIPTION
This closes #20
This removes eslint terminal warnings regarding the missing key prop in iteration elements.
The iterations in EntityList and CorrespondenceList got a custom key.
The iteration in AvatarBackground uses the loop index as key (instead of generating a custom identifier/hash) because ordering doesn't matter and there's some degree of randomness in the component anyway.
Thoughts?